### PR TITLE
Wagtail 5.1 upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 
 # Package dependencies
 install_requires = [
-    "wagtail>=4.1,<6.0",
+    "wagtail>=4.1",
     "wagtail-font-awesome-svg"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development',

--- a/wagtail_blocks/blocks.py
+++ b/wagtail_blocks/blocks.py
@@ -109,7 +109,7 @@ class ListWithImagesBlock(blocks.StructBlock):
 
     class Meta:
         template = 'wagtail_blocks/list_with_images.html'
-        icon = 'id-card-alt'
+        icon = 'id-card-clip'
 
 
 class SingleThumbnail(blocks.StructBlock):
@@ -180,7 +180,7 @@ class ChartBlock(blocks.StructBlock):
 
     class Meta:
         template = 'wagtail_blocks/chart.html'
-        icon = 'chart-bar'
+        icon = 'chart-column'
 
 
 class MapBlock(blocks.StructBlock):
@@ -220,4 +220,4 @@ class ImageSliderBlock(blocks.StructBlock):
 
     class Meta:
         template = 'wagtail_blocks/image_slider.html'
-        icon = 'sliders-h'
+        icon = 'sliders'

--- a/wagtail_blocks/wagtail_hooks.py
+++ b/wagtail_blocks/wagtail_hooks.py
@@ -4,8 +4,8 @@ from wagtail import hooks
 def register_icons(icons):
     return icons + [
         "wagtailfontawesomesvg/solid/camera-retro.svg",
-        "wagtailfontawesomesvg/solid/id-card-alt.svg",
+        "wagtailfontawesomesvg/solid/id-card-clip.svg",
         "wagtailfontawesomesvg/solid/object-ungroup.svg",
-        "wagtailfontawesomesvg/solid/chart-bar.svg",
-        "wagtailfontawesomesvg/solid/sliders-h.svg",
+        "wagtailfontawesomesvg/solid/chart-column.svg",
+        "wagtailfontawesomesvg/solid/sliders.svg",
     ]


### PR DESCRIPTION
Support ticket: https://torchbox.monday.com/boards/1124794299/pulses/1124795993

[Wagtail 5.1 release notes](https://docs.wagtail.org/en/stable/releases/5.1.html)

Upstream PR: https://github.com/ibrahimawadhamid/wagtail_blocks/pull/13

## Changes

### Update wagtailfontawesomesvg icons following module update from ~0.0.4 to ~1.0.1
The newest version of `wagtailfontawesomesvg` (1.0.1) has had some icon design changes and icon renames since 0.0.4

https://github.com/wagtail-nest/wagtail-font-awesome-svg/tree/0.0.4/wagtailfontawesomesvg
https://github.com/wagtail-nest/wagtail-font-awesome-svg/tree/1.0.1/wagtailfontawesomesvg