### PR TITLE
Correctly set default value for dataset_data in ChartDataset block

### DIFF
--- a/wagtail_blocks/blocks.py
+++ b/wagtail_blocks/blocks.py
@@ -148,9 +148,8 @@ class ChartDataset(blocks.StructBlock):
         default='Dataset #1',
     )
     dataset_data = blocks.ListBlock(
-        blocks.IntegerBlock(),
+        blocks.IntegerBlock(default=0),
         label='Data',
-        default='0',
     )
 
 


### PR DESCRIPTION
This pull request includes a small change to the `wagtail_blocks/blocks.py` file.

Correctly set default value for dataset_data in ChartDataset block

Wagtail core changed here: https://github.com/wagtail/wagtail/commits/d22ee56d4ce7a56842c04cce627b8049b7e523ed/wagtail/blocks/field_block.py
where the normalisation of the default value is now done in the ListBlock class.
This behaviour wasn't present in Wagtail earlier than 6.1